### PR TITLE
Let the Dialogue Manager fire NluIntent

### DIFF
--- a/rhasspysnips_nlu_hermes/__init__.py
+++ b/rhasspysnips_nlu_hermes/__init__.py
@@ -10,7 +10,6 @@ from rhasspyhermes.client import GeneratorType, HermesClient, TopicArgs
 from rhasspyhermes.intent import Intent, Slot, SlotRange
 from rhasspyhermes.nlu import (
     NluError,
-    NluIntent,
     NluIntentNotRecognized,
     NluIntentParsed,
     NluQuery,
@@ -62,7 +61,6 @@ class NluHermesMqtt(HermesClient):
     ) -> typing.AsyncIterable[
         typing.Union[
             NluIntentParsed,
-            typing.Tuple[NluIntent, TopicArgs],
             NluIntentNotRecognized,
             NluError,
         ]
@@ -108,22 +106,6 @@ class NluHermesMqtt(HermesClient):
                     slots=slots,
                 )
 
-                # intent
-                yield (
-                    NluIntent(
-                        input=query.input,
-                        id=query.id,
-                        site_id=query.site_id,
-                        session_id=query.session_id,
-                        intent=Intent(intent_name=intent_name, confidence_score=1.0),
-                        slots=slots,
-                        asr_tokens=[NluIntent.make_asr_tokens(query.input.split())],
-                        raw_input=original_input,
-                        wakeword_id=query.wakeword_id,
-                        lang=query.lang,
-                    ),
-                    {"intent_name": intent_name},
-                )
             else:
                 # Not recognized
                 yield NluIntentNotRecognized(


### PR DESCRIPTION
This is one of a series of patches for moving handling of NluIntent messages from the NLU modules to the Dialogue Manager, [according to the Hermes protocol](https://github.com/rhasspy/rhasspy-rasa-nlu-hermes/issues/3).